### PR TITLE
Windows compatibility update

### DIFF
--- a/pygamess/gamout_parser.py
+++ b/pygamess/gamout_parser.py
@@ -15,13 +15,17 @@ def gparse(gamout, parse_type="default"):
     r = GamessOut()
     out_str = open(gamout, "r").read()
 
-    # exited gracefully?
-    if not out_str.endswith("gracefully.\n"):
-        r.error_message = out_str[-1000:]
-        return r
-    else:
-        r.success = True
-    
+    # # exited gracefully?
+    # if not out_str.endswith("gracefully.\n"):
+    #     r.error_message = out_str[-1000:]
+    #     return r
+    # else:
+    #     r.success = True
+
+    # NOTE: Above check appears to be version-dependent.
+    #   Temporary fix: assume it worked until proven otherwise:
+    r.success = True
+
     if parse_type == "default":
         r = default_parse(out_str, r)
 
@@ -79,7 +83,7 @@ def default_parse(out_str, r):
     for m in nsearch_re.finditer(out_str):
         l = m.group(1).strip()
         r.nsearches.append(float(l.split()[-1]))
-                    
+
     # Coordinates
     for m in coord_re.finditer(out_str):
         r.coordinates = []
@@ -87,7 +91,7 @@ def default_parse(out_str, r):
             coord = l.split()
             cds = [float(coord[2]), float(coord[3]), float(coord[4])]
             r.coordinates.append(cds)
-    
+
     # MULLIKEN and LOWDIN charge
     for m in pop_re.finditer(out_str):
         r.mulliken_charges = []
@@ -97,7 +101,7 @@ def default_parse(out_str, r):
             if len(ls) == 6:
                 r.mulliken_charges.append(float(ls[3]))
                 r.lowdin_charges.append(float(ls[5]))
-    
+
     # Dipole morment
     for m in es_moment_re.finditer(out_str):
         r.dipole_moment = []
@@ -106,13 +110,13 @@ def default_parse(out_str, r):
             if len(ls) == 4:
                 for v in ls:
                     r.dipole_moment.append(float(v))
-    
+
     # Num of electrons
     m = num_electron_re.search(out_str)
     if m is not None:
         num_elec = m.group().split("=")[1][:-1]
         num_elec = int(num_elec)
-    
+
     # MO
     m = eigen_re.search(out_str)
     if m is not None:
@@ -138,7 +142,7 @@ def default_parse(out_str, r):
             if l.startswith("                  ") and l.find(".") > 0:
                 ls = [float(v) for v in l.split()]
                 mo_energies += ls
-    
+
     # HESSIAN
     r.is_stationary_point = None
     r.ZPE = None


### PR DESCRIPTION
I've introduced the following Windows compatibility changes, to enable successful `exec_rungms` and `run_input`:
1. Use cross-platform `os.path.pathsep` rather than ":" to split PATH variable.
2. Locate `rungms` script in `gamess_path` directory.
3. Execute `rungms` script explictly from within `gamess_path` directory, so that `rungms` script correctly locates `rungms.gms` config file.
4. Corrected `exec_rungms` using platform-specific "/" path delimiter.
5. Removed error redirection in `exec_rungms`.
6. Temporarily removed "gracefully." check in `parse`, since it always fails for all output files generated by my version of GAMESS (2020.R2.pgiblas).

Note that successfully running on Windows requires the `rungms_suffix=".bat"` keyword argument in the `Gamess` constructor, and of course the `executable_num` keyword argument should match the GAMES version. Finally, calling `run` requires the `use_rungms=True` keyword argument, so that `run` properly routes to `exec_rungms` rather than `py_rungms`, which has not been touched in this pull request.

Note that I added several comments starting with "NOTE:" worthy of your attention, but not necessarily worthy of being in the master branch. I do recommend documenting your code more thoroughly, though. ;)

Finally, a whole bunch of lines are marked as changed, because my text editor is configured to automatically delete whitespace at the end of a line. ...sorry about that...